### PR TITLE
Consume public package using the Actions-provided GITHUB_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         dotnet-version: 3.1.101
         source-url: https://nuget.pkg.github.com/fakutori/index.json
       env:
-        NUGET_AUTH_TOKEN: ${{secrets.READ_PRIVATE_PACKAGES_TOKEN}}
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Install dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
Context: reduce the scope of privileges here to only the repository in question