### PR TITLE
Use a PAT with only read:packages scope

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         dotnet-version: 3.1.101
         source-url: https://nuget.pkg.github.com/fakutori/index.json
       env:
-        NUGET_AUTH_TOKEN: ${{secrets.READ_PRIVATE_PACKAGES_TOKEN}}
+        NUGET_AUTH_TOKEN: ${{ secrets.READ_PACKAGES_TOKEN }} # PAT with only read:packages scope
     - name: Install dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
### What this PR does

Change to use a PAT with only `read:packages` scope to install packages from private repository.

At the moment our documentation suggests this isn't possible:

> To download and install packages from a repository, your token must have the `read:packages` scope, and your user account must have read permissions for the repository. If the repository is private, your token must also have the `repo` scope.

https://help.github.com/en/packages/publishing-and-managing-packages/about-github-packages#about-tokens

### Privilege escalation

PATs with the `repo` scope are implicitly given the `workflow` scope (even though this scope isn't checked when creating). This would allow a PAT to create a workflow that uses the `${{ secrets.GITHUB_TOKEN }}` to publish packages or read other secrets.
