### PR TITLE
Proof of concept "dotnet-restore" action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
+
+# Proof of concept "actions/dotnet-restore" action:
+# 1. Install nuget.org dependencies
+# 2. Install GPR dependencies
+# 3. Redact the GPR token
     - name: Install nuget.org dependencies
       run: dotnet restore
       continue-on-error: true
@@ -35,6 +39,13 @@ jobs:
         NUGET_AUTH_TOKEN: ${{secrets.READ_PRIVATE_PACKAGES_TOKEN}}
     - name: Install GPR dependencies
       run: dotnet restore
+    - name: Redact the GPR token
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+        source-url: https://nuget.pkg.github.com/fakutori/index.json
+      env:
+        NUGET_AUTH_TOKEN: REDACTED
 
     - name: Build
       run: dotnet build --no-restore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
         dotnet-version: 3.1.101
     - name: Install nuget.org dependencies
       run: dotnet restore
+      continue-on-error: true
     - name: Setup .NET Core for GPR
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,15 +18,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Install nuget.org dependencies
+      run: dotnet restore
+    - name: Setup .NET Core for GPR
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
         source-url: https://nuget.pkg.github.com/fakutori/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.READ_PRIVATE_PACKAGES_TOKEN}}
-    - name: Install dependencies
+    - name: Install GPR dependencies
       run: dotnet restore
+
     - name: Build
       run: dotnet build --no-restore
     - name: Run the application


### PR DESCRIPTION
This is a proof of concept of what a safe `dotnet-restore` action might do.

The action would do the following:
1. Install nuget.org dependencies
2. Install GPR dependencies
3. Redact the GPR token

This has the following advantages:
- Packages on `nuget.org` have priority, so packages can't be subsistuted using the GPR
- The GitHub token isn't visible in plan text after the action has run