### PR TITLE
Use %NUGET_AUTH_TOKEN% in nuget.config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.0.103
+        dotnet-version: 3.1.301
         source-url: https://nuget.pkg.github.com/fakutori/index.json
       env:
         NUGET_AUTH_TOKEN: '%NUGET_AUTH_TOKEN%'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 2.1.807
         source-url: https://nuget.pkg.github.com/fakutori/index.json
       env:
         NUGET_AUTH_TOKEN: '%NUGET_AUTH_TOKEN%'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,21 +14,27 @@ jobs:
       matrix:
         run: [1,2,3,4,5,6,7,8,9,10]
       fail-fast: false
+
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
         source-url: https://nuget.pkg.github.com/fakutori/index.json
       env:
-        NUGET_AUTH_TOKEN: ${{secrets.READ_PACKAGES_TOKEN}}
+        NUGET_AUTH_TOKEN: '%NUGET_AUTH_TOKEN%'
+
     - name: Install dependencies
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.READ_PACKAGES_TOKEN}}
       run: dotnet restore
+
     - name: Build
       run: dotnet build --no-restore
+
     - name: Run the application
       run: dotnet run --no-build
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.207
+        dotnet-version: 3.0.103
         source-url: https://nuget.pkg.github.com/fakutori/index.json
       env:
         NUGET_AUTH_TOKEN: '%NUGET_AUTH_TOKEN%'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.1.807
+        dotnet-version: 2.2.207
         source-url: https://nuget.pkg.github.com/fakutori/index.json
       env:
         NUGET_AUTH_TOKEN: '%NUGET_AUTH_TOKEN%'


### PR DESCRIPTION
Check to see if we could pass a token to `nuget.config` using an envvar (like we do with `setup/node` and `setup/java`).

Using `%NUGET_AUTH_TOKEN%` inside `nuget.config`:

- .NET Core SDK 3.1.301 ✅ 
- .NET Core SDK 3.0.103 🔴
- .NET Core SDK 2.1.807 🔴
- .NET Core SDK 2.2.207 🔴

This appears to have been [fixed](https://github.com/fakutori/consume-package/runs/811379712) in .NET Core SDK 3.1.